### PR TITLE
Add github action workflow to release docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - 'main'
+jobs:
+  push_to_registry:
+    if: contains(github.event.head_commit.message, 'released new version')
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ericguo/oauth2id
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }},ericguo/oauth2id:latest
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
After git push, when the text "released new version" is detected, the process of automatically building a Docker image will be executed and pushed to Docker Hub in namespace **ericguo**

Need to config docker hub username and docker token in github project secrect settings.